### PR TITLE
Add example of running tunmgr in Kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,5 @@ Auto tunnels will be established for:
 1. [https://antonio-ce37a3511391.tuns.sh](https://tuns.sh)
 2. [https://antonio-httpbin.tuns.sh](https://tuns.sh)
 3. [https://antonio-tunmgr-httpbin-1.tuns.sh](https://tuns.sh)
+
+See also the `examples` folder of this repo.

--- a/examples/example-docker-compose.yaml
+++ b/examples/example-docker-compose.yaml
@@ -1,0 +1,27 @@
+services:
+  tunmgr:
+    image: ghcr.io/picosh/tunmgr:latest
+    restart: always
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - $HOME/.ssh/id_ed25519_pico_antonio:/key:ro
+    # ports: # Ports map for local tunnels like below
+    #   - 8000:8000
+    # command: | # Provide other commands below
+    #   -only-labels=true
+    #   -local-tunnel=0.0.0.0:8000:antonio-httpbin:8000
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 2s
+      timeout: 5s
+      retries: 5
+      start_period: 1s
+  httpbin:
+    image: kennethreitz/httpbin
+    depends_on:
+      tunmgr:
+        condition: service_healthy
+    # labels: # or provide tunnel names and ports explicitly
+    #   tunmgr.names: httpbin # Comma separated list of names. Can be an empty. If empty, allows for tcp forward (or random name).
+    #   tunmgr.ports: 8000:80,80:80 # Comma separated list of port maps. (remote:local). First is alias, second is http.
+    command: gunicorn -b 0.0.0.0:80 httpbin:app -k gevent --access-logfile -

--- a/examples/kubernetes/README.md
+++ b/examples/kubernetes/README.md
@@ -1,0 +1,35 @@
+# tunmgr with Kustomize
+
+Here's an example of installing tunmgr using Kustomize with your own overrides. We recommend proxying all traffic through an [Ingress Controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/) or a [Gateway](https://kubernetes.io/docs/concepts/services-networking/gateway/) for maximum flexibility.
+
+Create a `kustomization.yaml` file like the following:
+
+```yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+# We recommend pinning a specific commit SHA instead of main
+- https://github.com/picosh/tunmgr//examples/kubernetes?ref=main
+# Bring your own secret
+- secret.yaml
+namespace: tunmgr
+patches:
+- patch: |-
+    - op: add
+      path: /spec/template/spec/containers/0/args/-
+      value: -tunnel=mysite.example.com:80:traefik.traefik.svc.cluster.local:80
+```
+
+Also create a `secret.yaml` file:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ssh-key
+type: Opaque
+stringData:
+  id_ed25519: PUT_YOUR_PRIVATE_KEY_HERE
+```
+
+Then you can install it with `kubectl apply -k .`

--- a/examples/kubernetes/kustomization.yaml
+++ b/examples/kubernetes/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- resources.yaml
+
+namespace: tunmgr

--- a/examples/kubernetes/resources.yaml
+++ b/examples/kubernetes/resources.yaml
@@ -1,0 +1,72 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tunmgr
+  labels:
+    app.kubernetes.io/name: tunmgr
+spec:
+  revisionHistoryLimit: 3
+  replicas: 1
+  strategy:
+    # tuns.sh doesn't enable load balancing https://docs.ssi.sh/advanced#load-balancing
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: tunmgr
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: tunmgr
+    spec:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        fsGroup: 1000
+      containers:
+        - name: tunmgr
+          image: ghcr.io/picosh/tunmgr:latest
+          imagePullPolicy: Always
+          args:
+            - -docker-events=false
+            - -remote-key-location=/key/id_ed25519
+            # Add your own args
+          volumeMounts:
+          - name: ssh-key
+            mountPath: /key
+            readOnly: true
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          # Tunmgr binds to localhost so this probe won't work
+          # readinessProbe:
+          #   httpGet:
+          #     path: /health
+          #     port: http
+          #   initialDelaySeconds: 1
+          #   failureThreshold: 3
+          #   timeoutSeconds: 1
+          #   periodSeconds: 10
+          resources:
+            requests:
+              cpu: 50m
+              memory: 50Mi
+            limits:
+              memory: 200Mi
+              ephemeral-storage: 100Mi
+          securityContext:
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            seccompProfile:
+              type: RuntimeDefault
+      volumes:
+      - name: ssh-key
+        secret:
+          secretName: ssh-key
+          defaultMode: 0400


### PR DESCRIPTION
I was able to package tunmgr up into a Kubernetes Deployment and it has been running smoothly for a few weeks now. Thought I'd contribute it back as an example.

The Deployment includes security best-practices and is installable using Kustomize.

Using Kustomize instead of Helm means everything can be overridden, so less maintenance burden (in theory).